### PR TITLE
Allow TLS certificate errors for activation

### DIFF
--- a/lib/activate.js
+++ b/lib/activate.js
@@ -38,7 +38,12 @@ async function start(email, password, alf, verificationCode, emailPassword, auth
 
     // Launch Headless browser
     const browser = await puppeteer.launch({
-      args: ['--no-sandbox', '--disable-setuid-sandbox']
+      args: [
+        '--no-sandbox',
+        '--disable-setuid-sandbox',
+        '--ignore-certificate-errors'
+      ],
+      ignoreHTTPSErrors: true
     });
     const page = await browser.newPage();
 


### PR DESCRIPTION
## Summary
- modify `puppeteer.launch` arguments
- ignore HTTPS errors to prevent TLS issues when retrieving a license

## Testing
- `npm test` *(fails: Error: no test specified)*