### PR TITLE
Update SSL option to match latest Puppeteer

### DIFF
--- a/lib/activate.js
+++ b/lib/activate.js
@@ -43,7 +43,7 @@ async function start(email, password, alf, verificationCode, emailPassword, auth
         '--disable-setuid-sandbox',
         '--ignore-certificate-errors'
       ],
-      ignoreHTTPSErrors: true
+      acceptInsecureCerts: true
     });
     const page = await browser.newPage();
 


### PR DESCRIPTION
## Summary
- update Puppeteer launch option to use `acceptInsecureCerts`

## Testing
- `npm test` *(fails: Error: no test specified)*